### PR TITLE
class and instance methods with the same name

### DIFF
--- a/rails7/app/controllers/agents_controller.rb
+++ b/rails7/app/controllers/agents_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require Rails.root.join('lib/custom_helpers')
+require Rails.root.join('lib/which_is_which')
 
 class AgentsController < ApplicationController
   before_action :set_agent, only: %i[show edit update destroy]
@@ -16,6 +17,8 @@ class AgentsController < ApplicationController
   def show
     ::Custom::Helpers.custom_class_method
     ::Custom::Helpers.new.custom_instance_method
+    ::WhichIsWhich.samename
+    ::WhichIsWhich.new.samename
   end
 
   # GET /agents/new

--- a/rails7/lib/which_is_which.rb
+++ b/rails7/lib/which_is_which.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'tasks/newrelic'
+
+class WhichIsWhich
+  include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
+  include ::NewRelic::Agent::MethodTracer
+
+  def self.samename
+    'Class (static) method named samename'
+  end
+
+  class << self
+    include ::NewRelic::Agent::Instrumentation::ControllerInstrumentation
+    include ::NewRelic::Agent::MethodTracer
+    add_transaction_tracer :samename, category: :task
+  end
+
+  def samename
+    'Instance method named samename'
+  end
+  add_transaction_tracer :samename, category: :task
+end


### PR DESCRIPTION
Have the New Relic Ruby agent report on code level metrics for two
separate methods with transaction traces. Both methods bear the same
name and are defined in the same class. One is an instance method and
one is a class (static) method.

When the demo runs, 2 new spans (1 for each method) will recorded within
the `agents#show` controller method transaction.

These spans will appear to be almost identical, with the `code.lineno`
value being the key CLM difference between the two.

The class is named `WhichIsWhich` and the methods are named `samename`.