### PR TITLE
point Gemfile to production newrelic_rpm

### DIFF
--- a/rails7/Gemfile
+++ b/rails7/Gemfile
@@ -4,8 +4,7 @@ source 'https://rubygems.org'
 
 ruby '3.1.2'
 
-gem 'newrelic_rpm', git: 'https://github.com/newrelic/newrelic-ruby-agent.git',
-                    branch: 'method_level_telemetry'
+gem 'newrelic_rpm', '>= 8.8.0'
 
 gem 'puma', '~> 5.0'
 gem 'rails', '~> 7.0.2', '>= 7.0.2.3'


### PR DESCRIPTION
point to the newrelic_rpm out on RubyGems.org now that it includes code
level metrics functionality